### PR TITLE
Set up endpoint to fetch course's sections

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -6,6 +6,8 @@ from app.views.course import CourseViewSet
 from app.views.course_member import CourseMemberViewSet
 from app.views.relationship import RelationshipViewSet
 from app.views.section import SectionViewSet
+from app.views.course_sections import CourseSectionViewSet
+
 from app.views.teams import (
     TeamViewSet,
     TeamSetViewSet,
@@ -17,6 +19,7 @@ router = routers.DefaultRouter()
 router.register("courses", CourseViewSet)
 router.register("sections", SectionViewSet)
 router.register("course-members", CourseMemberViewSet)
+router.register("course-sections", CourseSectionViewSet)
 router.register("relationships", RelationshipViewSet)
 router.register("teams", TeamViewSet)
 router.register("teamsets", TeamSetViewSet)
@@ -30,5 +33,10 @@ urlpatterns = [
         "course-members/course/<int:course>/",
         CourseMemberViewSet.as_view({"get": "get_students_by_course"}),
         name="get-students-by-course",
+    ),
+    path(
+        "course/<int:course>/sections/",
+        CourseSectionViewSet.as_view({"get": "get_course_sections"}),
+        name="get_course_sections",
     ),
 ]

--- a/app/views/course_sections.py
+++ b/app/views/course_sections.py
@@ -1,0 +1,19 @@
+from rest_framework import viewsets
+from rest_framework.response import Response
+from rest_framework import status
+
+from app.models.section import Section
+from app.models.course import Course
+from app.serializers.section import SectionSerializer
+
+
+class CourseSectionViewSet(viewsets.ModelViewSet):
+    queryset = Section.objects.all()
+    serializer_class = SectionSerializer
+
+    def get_course_sections(self, request, course):
+        if not Course.objects.filter(id=course).exists():
+            return Response({"error": "Course not found"}, status=404)
+        sections = Section.objects.filter(course=course)
+        serializer = SectionSerializer(sections, many=True)
+        return Response(serializer.data)

--- a/app/views/course_sections.py
+++ b/app/views/course_sections.py
@@ -1,6 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
-from rest_framework import status
+from django.shortcuts import get_object_or_404
 
 from app.models.section import Section
 from app.models.course import Course
@@ -12,8 +12,7 @@ class CourseSectionViewSet(viewsets.ModelViewSet):
     serializer_class = SectionSerializer
 
     def get_course_sections(self, request, course):
-        if not Course.objects.filter(id=course).exists():
-            return Response({"error": "Course not found"}, status=404)
-        sections = Section.objects.filter(course=course)
-        serializer = SectionSerializer(sections, many=True)
+        course = get_object_or_404(Course, pk=course)
+        course.sections.set(Section.objects.filter(course=course))
+        serializer = SectionSerializer(course.sections, many=True)
         return Response(serializer.data)

--- a/app/views/course_sections.py
+++ b/app/views/course_sections.py
@@ -13,6 +13,5 @@ class CourseSectionViewSet(viewsets.ModelViewSet):
 
     def get_course_sections(self, request, course):
         course = get_object_or_404(Course, pk=course)
-        course.sections.set(Section.objects.filter(course=course))
         serializer = SectionSerializer(course.sections, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
For task 2.3 (a): see [specs](https://docs.google.com/document/d/1HnkzVgKEJ5RhQ9g8VR6K66lvKfx97stT699y252C1dI/edit)

- Able to retrieve the set of section objects from a course by using a new endpoint: `course/[id]/sections`

- Added new viewset file, `CourseSectionViewSet` which filters queryset of sections on the course id from the endpoint.