### PR TITLE
Update course members sections

### DIFF
--- a/app/serializers/course_member.py
+++ b/app/serializers/course_member.py
@@ -19,5 +19,5 @@ class CourseMemberSerializer(serializers.ModelSerializer):
     sections = SectionSerializer(many=True, read_only=True)
 
     class Meta:
-        model = CourseMember 
+        model = CourseMember
         fields = "__all__"

--- a/app/serializers/course_member.py
+++ b/app/serializers/course_member.py
@@ -19,5 +19,5 @@ class CourseMemberSerializer(serializers.ModelSerializer):
     sections = SectionSerializer(many=True, read_only=True)
 
     class Meta:
-        model = CourseMember
+        model = CourseMember 
         fields = "__all__"

--- a/app/views/course_member.py
+++ b/app/views/course_member.py
@@ -37,7 +37,7 @@ class CourseMemberViewSet(viewsets.ModelViewSet):
         else:
             serializer = self.get_serializer(queryset, many=True)
             return Response(serializer.data)
-    
+
     def fetch_course_sections(self, course_id):
         course = get_object_or_404(Course, pk=course_id)
         sections = course.sections.all()
@@ -50,20 +50,34 @@ class CourseMemberViewSet(viewsets.ModelViewSet):
         section_ids = request.data.get("sections")
 
         if section_ids is None:
-            return Response({"message": "Sections are required."}, status=status.HTTP_400_BAD_REQUEST)      
+            return Response(
+                {"message": "Sections are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         if not isinstance(section_ids, list):
-            return Response({"message": "Sections must be a list."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"message": "Sections must be a list."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             section_ids = [int(section_id) for section_id in section_ids]
         except ValueError:
-            return Response({"message": "Sections must be integers."}, status=status.HTTP_400_BAD_REQUEST)
-        
+            return Response(
+                {"message": "Sections must be integers."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         course_sections = self.fetch_course_sections(course_member.course.id)
         valid_section_ids = {section["id"] for section in course_sections}
 
         if not set(section_ids).issubset(valid_section_ids):
-            return Response({"message": "One or more sections are not part of the course."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"message": "One or more sections are not part of the course."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         proposed_new_sections = Section.objects.filter(id__in=section_ids)
-        course_member.sections.set(proposed_new_sections)   
-        return Response({"message": "Sections updated successfully."}, status=status.HTTP_200_OK)
+        course_member.sections.set(proposed_new_sections)
+        return Response(
+            {"message": "Sections updated successfully."}, status=status.HTTP_200_OK
+        )

--- a/app/views/course_member.py
+++ b/app/views/course_member.py
@@ -2,10 +2,17 @@ from rest_framework import viewsets
 
 from app.models.course_member import CourseMember
 from app.paginators.pagination import ExamplePagination
+from app.models.section import Section
+from app.models.course import Course
 from app.filters.course_member import FilterStudents
 from app.serializers.course_member import CourseMemberSerializer
+from app.serializers.section import SectionSerializer
 
 from rest_framework.response import Response
+from rest_framework.decorators import action
+from rest_framework import status
+
+from django.shortcuts import get_object_or_404
 
 
 class CourseMemberViewSet(viewsets.ModelViewSet):
@@ -30,3 +37,33 @@ class CourseMemberViewSet(viewsets.ModelViewSet):
         else:
             serializer = self.get_serializer(queryset, many=True)
             return Response(serializer.data)
+    
+    def fetch_course_sections(self, course_id):
+        course = get_object_or_404(Course, pk=course_id)
+        sections = course.sections.all()
+        serializer = SectionSerializer(sections, many=True)
+        return serializer.data
+
+    @action(detail=True, methods=["put"], url_path="update-sections")
+    def update_sections(self, request, *args, **kwargs):
+        course_member = self.get_object()
+        section_ids = request.data.get("sections")
+
+        if section_ids is None:
+            return Response({"message": "Sections are required."}, status=status.HTTP_400_BAD_REQUEST)      
+        if not isinstance(section_ids, list):
+            return Response({"message": "Sections must be a list."}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            section_ids = [int(section_id) for section_id in section_ids]
+        except ValueError:
+            return Response({"message": "Sections must be integers."}, status=status.HTTP_400_BAD_REQUEST)
+        
+        course_sections = self.fetch_course_sections(course_member.course.id)
+        valid_section_ids = {section["id"] for section in course_sections}
+
+        if not set(section_ids).issubset(valid_section_ids):
+            return Response({"message": "One or more sections are not part of the course."}, status=status.HTTP_400_BAD_REQUEST)
+
+        proposed_new_sections = Section.objects.filter(id__in=section_ids)
+        course_member.sections.set(proposed_new_sections)   
+        return Response({"message": "Sections updated successfully."}, status=status.HTTP_200_OK)


### PR DESCRIPTION
 - using `action` decorator to set up endpoint: `api/v1/course-members/{id}/update-sections/`
 - now validating the request.data so that it accepts only:
    - list of numbers
    - no strings
    - no sections that are not in the course of the course-member
 

Not sure about this case:
Student is enrolled in Course 1 and 2. Course 1 has sections X and Y. Course 2 has sections Z
If student is enrolled in multiple courses, could I technically update student to be section Z for course A?